### PR TITLE
Fix changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,11 +18,7 @@ All notable changes to this project will be documented in this file. See [standa
 
 
 
-# Change Log
-
-All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
-
-# 2.1.0 (2019-02-16)
+# [2.1.0](https://github.com/kimkwanka/niru/compare/2.0.0...v2.1.0) (2019-02-16)
 
 
 ### Bug Fixes
@@ -38,4 +34,3 @@ All notable changes to this project will be documented in this file. See [standa
 
 
 
-# 2.0.0 (2019-02-16)

--- a/package-lock.json
+++ b/package-lock.json
@@ -10124,9 +10124,8 @@
       "dev": true
     },
     "standard-version": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-5.0.0.tgz",
-      "integrity": "sha512-ODn74fVhNVxmVD65YaNour7pHmJ/7fXuINPsTha2OndLmrajBmUz2q1Ah5s7lChTzWUe78F6uinRMpiSxvZKfw==",
+      "version": "git+https://github.com/kimkwanka/standard-version.git#51ee95aa372b2c17cc45820768f8372336a94ca0",
+      "from": "git+https://github.com/kimkwanka/standard-version.git",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "redux-logger": "^3.0.6",
     "redux-mock-store": "^1.5.3",
     "reload": "^2.4.0",
-    "standard-version": "^5.0.0",
+    "standard-version": "https://github.com/kimkwanka/standard-version.git",
     "supertest": "^3.4.2",
     "webpack-dev-middleware": "^3.5.2",
     "webpack-hot-middleware": "^2.24.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8109,10 +8109,9 @@ stack-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
   integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
 
-standard-version@^5.0.0:
+"standard-version@https://github.com/kimkwanka/standard-version.git":
   version "5.0.0"
-  resolved "https://registry.yarnpkg.com/standard-version/-/standard-version-5.0.0.tgz#b4543fbf1e7e2ef70a7085150c5b0a91eb754c97"
-  integrity sha512-ODn74fVhNVxmVD65YaNour7pHmJ/7fXuINPsTha2OndLmrajBmUz2q1Ah5s7lChTzWUe78F6uinRMpiSxvZKfw==
+  resolved "https://github.com/kimkwanka/standard-version.git#51ee95aa372b2c17cc45820768f8372336a94ca0"
   dependencies:
     chalk "^2.4.1"
     conventional-changelog "^3.0.6"


### PR DESCRIPTION
Currently there is an issue with standard-version where the last "Change log" section of CHANGELOG.md is not removed when updating.

[This PR](https://github.com/conventional-changelog/standard-version/pull/292) fixes this issue but has yet to approved.

Until then, we use a custom fork that has this exact fix already merged into it.