### PR TITLE
refactor: use fixed standard-version@5.0.1 instead of fork

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10219,8 +10219,9 @@
       "dev": true
     },
     "standard-version": {
-      "version": "git+https://github.com/kimkwanka/standard-version.git#51ee95aa372b2c17cc45820768f8372336a94ca0",
-      "from": "git+https://github.com/kimkwanka/standard-version.git",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/standard-version/-/standard-version-5.0.1.tgz",
+      "integrity": "sha512-nlab5/C0P1Zd5k/2Zer/Y8xDnyf9kHES8Hy82aO8owJG9TJb3KbdNNOBNAgfa/ZsiDlJE9WQTGm1yN2VM1qxTg==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "redux-logger": "^3.0.6",
     "redux-mock-store": "^1.5.3",
     "reload": "^2.4.0",
-    "standard-version": "https://github.com/kimkwanka/standard-version.git",
+    "standard-version": "^5.0.1",
     "supertest": "^3.4.2",
     "webpack-dev-middleware": "^3.6.0",
     "webpack-hot-middleware": "^2.24.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8192,9 +8192,10 @@ stack-utils@^1.0.1:
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
   integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
 
-"standard-version@https://github.com/kimkwanka/standard-version.git":
-  version "5.0.0"
-  resolved "https://github.com/kimkwanka/standard-version.git#51ee95aa372b2c17cc45820768f8372336a94ca0"
+standard-version@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/standard-version/-/standard-version-5.0.1.tgz#b2b2e858379c75b7da25fbc1cdafe8b6f36810d3"
+  integrity sha512-nlab5/C0P1Zd5k/2Zer/Y8xDnyf9kHES8Hy82aO8owJG9TJb3KbdNNOBNAgfa/ZsiDlJE9WQTGm1yN2VM1qxTg==
   dependencies:
     chalk "^2.4.1"
     conventional-changelog "^3.0.6"


### PR DESCRIPTION
Custom fork (see PR #5) is no longer needed since ```standard-version@5.0.1``` incorporates said fix now.